### PR TITLE
Fix boolean comparison

### DIFF
--- a/includes/class-gallery-img-frontend-scripts.php
+++ b/includes/class-gallery-img-frontend-scripts.php
@@ -114,15 +114,15 @@ class Gallery_Img_Frontend_Scripts {
 		$gallery_default_params = gallery_img_get_default_options();
 		$query = $wpdb->prepare( "SELECT image_url FROM " . $wpdb->prefix . "huge_itgallery_images WHERE gallery_id=%d", $id );
 		$images       = $wpdb->get_col( $query );
-		$has_youtube  = 'false';
-		$has_vimeo    = 'false';
+		$has_youtube  = false;
+		$has_vimeo    = false;
 		$view_slug = gallery_img_get_view_slag_by_id( $id );
 		foreach ( $images as $image_row ) {
 			if ( strpos( $image_row, 'youtu' ) !== false ) {
-				$has_youtube = 'true';
+				$has_youtube = true;
 			}
 			if ( strpos( $image_row, 'vimeo' ) !== false ) {
-				$has_vimeo = 'true';
+				$has_vimeo = true;
 			}
 		}
 

--- a/includes/class-gallery-img-template-loader.php
+++ b/includes/class-gallery-img-template-loader.php
@@ -42,14 +42,14 @@ class Gallery_Img_Template_Loader {
         $slideshow_title_position = explode('-', $trim_slider_title_position);
         $trim_slider_description_position = trim($gallery_default_params['slider_description_position']);
         $slideshow_description_position = explode('-', $trim_slider_description_position);
-        $has_youtube  = 'false';
-        $has_vimeo    = 'false';
+        $has_youtube  = false;
+        $has_vimeo    = false;
         foreach ( $images as $image ) {
             if ( strpos( $image->image_url, 'youtu' ) !== false ) {
-                $has_youtube = 'true';
+                $has_youtube = true;
             }
             if ( strpos( $image->image_url, 'vimeo' ) !== false ) {
-                $has_vimeo = 'true';
+                $has_vimeo = true;
             }
         }
 		if ( isset( $_GET[ 'page-img' . $galleryID . $pID ] ) ) {

--- a/templates/front-end/view/slider/slider-view.php
+++ b/templates/front-end/view/slider/slider-view.php
@@ -512,7 +512,7 @@
 	}
 	function huge_it_change_image_gallery_<?php echo $galleryID; ?>(current_key, key, data_gallery_<?php echo $galleryID; ?>, from_effect,clicked) {
 		if (data_gallery_<?php echo $galleryID; ?>[key]) {
-			if(video_is_playing_gallery_<?php echo $galleryID; ?> && !clicked){
+			if(typeof video_is_playing_gallery_<?php echo $galleryID; ?> != 'undefined' && video_is_playing_gallery_<?php echo $galleryID; ?> && !clicked){
 				return false;
 			}
 			if (!from_effect) {


### PR DESCRIPTION
`$has_vimeo` and `$has_youtube` were set to the string `'true'` or `'false'`, and because `('false' == true) === true` the video code was always being included.

When `$has_vimeo == false`, `typeof video_is_playing_gallery_<?php echo $galleryID; ?>` will be undefined so added check for that as well